### PR TITLE
fix: dns ttl parsing on router os 7

### DIFF
--- a/commands/dns.py
+++ b/commands/dns.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from commands.basecommand import BaseCommand
-
+from util.parse_ttl import parse_ttl
 
 class DNS(BaseCommand):
     def __init__(self):
@@ -24,7 +24,8 @@ class DNS(BaseCommand):
         recommendation = []
 
         for item in res:
-            if int(item['ttl'].partition('s')[0]) > 200000:
+            item['parsed_ttl'] = parse_ttl(item['ttl'])
+            if item['parsed_ttl'] > 200000:
                 sus_dns.append(f'Domain name: {item["name"]} with ip {item["address"]}: might be DNS poisoning- '
                                f'severity: high')
 

--- a/util/parse_ttl.py
+++ b/util/parse_ttl.py
@@ -1,0 +1,31 @@
+def parse_ttl(s_ttl):
+    if s_ttl.isdigit():
+        return int(s_ttl)
+    map =  {
+        'd': 24 * 60 * 60,
+        'h': 60 * 60,
+        'm': 60,
+        's': 1
+    }
+    ttl = 0
+    input = s_ttl
+    for key in map:
+        parts = input.split(key, 1)
+        if len(parts) == 2:
+            ttl = ttl + (int(parts[0]) * map[key])
+            input = parts[1]
+    return ttl
+
+
+if __name__ == '__main__':
+    tests = {
+        '1234': 1234,
+        '1234s': 1234,
+        '1d2h3m4s': 93784,
+        '1h2m3s': 3723,
+        '1m2s': 62,
+        '1s': 1,
+    }
+    for input in tests:
+        output = parse_ttl(input)
+        print(f'Input: {input}\tOutput: {output}\nPassed: {output == tests[input]}\n')


### PR DESCRIPTION
Fixes the DNS TTL parsing in Router OS 7.

The TTL values on RouterOS 7 are in the format `1d2h3m4s`, whereas previously they were `123s`