### PR TITLE
Slight optimization when getting version, add concise argument - prints only suspicious and recommended items

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This tool’s functionalities include the following:
 `-u`	  | User name with admin Permissions		                        | Must
 `-ps`     | The password of the given user name	(empty password by defoult)	| Optional
 `-J`	  | Print the results as json format (prints txt format by defoult)	| Optional
+`-concise`| Print a shortened text output focusing on recommendations       | Optional
 
 ### Executing examples:
 	 ./main.py -i 1.2.3.4 -p 22 -u admin

--- a/commands/version.py
+++ b/commands/version.py
@@ -11,30 +11,29 @@ class Version(BaseCommand):
         self.__name__ = 'Version'
 
     def run_ssh(self, sshc):
-        version = ''
-        res = ''
-        data = self._ssh_data(sshc, '/system resource print')
-        version_reg = re.search(r'version: ([\d\.]+)', data)
+        data = self._ssh_data(sshc, ':put [/system resource get version]')
+        
+        version_reg = re.search(r'([\d\.]+)', data)
 
         if version_reg:
             version = version_reg.group(1)
-            res = f'The Mikrotik version: {version}'
 
-        sus_dns, recommendation = self.check_results_ssh(version)
+        sus, recommendation = self.check_results_ssh(version)
 
-        return {'raw_data': res,
-                'suspicious': sus_dns,
+        return {'raw_data': data,
+                'suspicious': sus,
                 'recommendation': recommendation}
 
-    def check_results_ssh(self, res):
+    def check_results_ssh(self, version):
         sus_version = []
         recommendation = []
 
-        if res:
+        if version:
             cve = CVEValidator('./assets/mikrotik_cpe_match.json')
-            ver_cves = cve.check_version(res)
+            ver_cves = cve.check_version(version)
             if ver_cves:
                 sus_version = ver_cves
+                recommendation.append(f'Mikrotik version: {version} is vulnerable to CVE(s). Upgrade to the latest version.')
 
         return sus_version, recommendation
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import paramiko
+from pprint import pprint
 
 from commands.fwnat import FWNat
 from commands.dns import DNS
@@ -34,14 +35,18 @@ def main(args):
         if args.J:
             print(json.dumps(all_data, indent=4))
         else:
-            print_txt_results(all_data)
+            print_txt_results(all_data, args.concise)
 
-
-def print_txt_results(res):
+def print_txt_results(res, concise):
     for command in res:
-        print(f'{command}:')
+        command_printed = False
         for item in res[command]:
+            if concise and item != "recommendation" and item != "suspicious":
+                    continue     
             if res[command][item]:
+                if not command_printed: print(f'{command}:')
+                command_printed = True
+
                 print(f'\t{item}:')
                 if type(res[command][item]) == list:
                     data = '\n\t\t'.join(json.dumps(i) for i in res[command][item])
@@ -57,6 +62,7 @@ if __name__ == '__main__':
     parser.add_argument('-u', '--userName', help='User name with admin Permissions', required=True)
     parser.add_argument('-ps', '--password', help='The password of the given user name', default='')
     parser.add_argument('-J', help='Print the results as json format', action='store_true')
+    parser.add_argument('-concise', help='Print out only suspicious items and recommendations', action='store_true')
     args = parser.parse_args()
 
     main(args)


### PR DESCRIPTION
Only get version number so printing raw data makes more sense.
Add `concise` argument for printing much shorter and easier to read text output