### PR TITLE
Fix: TTL value, invalid literal for int() - dns.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This tool’s functionalities include the following:
 `-i`	  | The tested Mikrotik IP address			                        | Must
 `-p`	  | The tested Mikrotik SSH port			                        | Must
 `-u`	  | User name with admin Permissions		                        | Must
-`-ps`     | The password of the given user name	(empty password by defoult)	| Optional
-`-J`	  | Print the results as json format (prints txt format by defoult)	| Optional
+`-ps`     | The password of the given user name	(empty password by default)	| Optional
+`-J`	  | Print the results as json format (prints txt format by default)	| Optional
 
 ### Executing examples:
 	 ./main.py -i 1.2.3.4 -p 22 -u admin

--- a/commands/dns.py
+++ b/commands/dns.py
@@ -8,19 +8,18 @@ from commands.basecommand import BaseCommand
 
 class DNS(BaseCommand):
     def __init__(self):
+        self.rx = re.compile('(\d+d)?(\d+h)?(\d+m)?(\d+s)?')
         self.__name__ = 'DNS Cache'
 
     def get_seconds(self, ttl):
-        rx = re.compile('(\d+d)?(\d+h)?(\d+m)?(\d+s)?')
-        groups = rx.match(ttl).groups()
+        groups = self.rx.match(ttl).groups()
         d=0 if not groups[0] else int(groups[0][:-1])
         h=0 if not groups[1] else int(groups[1][:-1])
         m=0 if not groups[2] else int(groups[2][:-1])
         s=0 if not groups[3] else int(groups[3][:-1])
         h=h+(d*24)
-        s=s+(m*60)+((h*60)*60)
-
-        return int(s)
+        s=s+(m*60)+(h*3600)
+        return s
 
     def run_ssh(self, sshc):
         data = self._ssh_data(sshc, '/ip dns print')

--- a/commands/dns.py
+++ b/commands/dns.py
@@ -1,12 +1,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from commands.basecommand import BaseCommand
+import time
+import re
 
+from commands.basecommand import BaseCommand
 
 class DNS(BaseCommand):
     def __init__(self):
         self.__name__ = 'DNS Cache'
+
+    def get_seconds(self, ttl):
+        rx = re.compile('(\d+d)?(\d+h)?(\d+m)?(\d+s)?')
+        groups = rx.match(ttl).groups()
+        d=0 if not groups[0] else int(groups[0][:-1])
+        h=0 if not groups[1] else int(groups[1][:-1])
+        m=0 if not groups[2] else int(groups[2][:-1])
+        s=0 if not groups[3] else int(groups[3][:-1])
+        h=h+(d*24)
+        s=s+(m*60)+((h*60)*60)
+
+        return int(s)
 
     def run_ssh(self, sshc):
         data = self._ssh_data(sshc, '/ip dns print')
@@ -24,18 +38,11 @@ class DNS(BaseCommand):
         recommendation = []
 
         for item in res:
-            if int(item['ttl'].partition('s')[0]) > 200000:
-                sus_dns.append(f'Domain name: {item["name"]} with ip {item["address"]}: might be DNS poisoning- '
+            if self.get_seconds(item['ttl']) > 200000:
+                sus_dns.append(f'Domain name: {item["name"]} with ip {item["data"]}: might be DNS poisoning- '
                                f'severity: high')
 
         if enabled:
             recommendation.append('In case DNS cache is not required on your router - disable it')
 
         return sus_dns, recommendation
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixed "invalid literal for int()" error:
1. function get_seconds(ttl) - parses the time string from item["ttl"]
2. item["address"] does not exist, it is the next error. The correct column name is item["data"].

Tests on routeros versions 6.49 and 7.1.3.